### PR TITLE
Workaround for setting the license in the generated pom.xml

### DIFF
--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -9,6 +9,21 @@ shipkit {
     ]
 }
 
+// workaround for https://github.com/mockito/shipkit/issues/755
+plugins.withId("org.shipkit.java-publish") {
+        publishing.publications.javaLibrary.pom.withXml {
+            //refer to Groovy xml Node reference for more info how to manipulate xml
+            asNode().licenses.replaceNode {
+                licenses {
+                    license {
+                        name "Apache License, Version 2.0"
+                        url "https://www.apache.org/licenses/LICENSE-2.0"
+                    }
+                }
+            }
+        }
+}
+
 allprojects {
     plugins.withId("com.jfrog.bintray") {
         bintray {


### PR DESCRIPTION
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>