### PR TITLE
Bumping up Open Tracing dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,11 +21,11 @@ dependencies {
     api 'org.eclipse.microprofile.opentracing:microprofile-opentracing-api:1.1'
 
     implementation 'javax:javaee-api:7.0'
-    implementation 'io.opentracing:opentracing-api:0.31.0'
-    implementation 'io.opentracing.contrib:opentracing-tracerresolver:0.1.5'
+    implementation 'io.opentracing:opentracing-api:0.33.0'
+    implementation 'io.opentracing.contrib:opentracing-tracerresolver:0.1.8'
 
     testCompile 'junit:junit:4.12'
-    testImplementation 'io.opentracing:opentracing-mock:0.31.0'
+    testImplementation 'io.opentracing:opentracing-mock:0.33.0'
     testImplementation 'org.apache.tomee:openejb-core:7.1.0'
 }
 

--- a/src/main/java/io/opentracing/contrib/interceptors/OpenTracingInterceptor.java
+++ b/src/main/java/io/opentracing/contrib/interceptors/OpenTracingInterceptor.java
@@ -72,9 +72,8 @@ public class OpenTracingInterceptor {
         }
 
         Span span = spanBuilder.start();
-        Scope scope = null;
+        Scope scope = tracer.activateSpan(span);
         try {
-            scope = tracer.activateSpan(span);
             log.fine("Adding span context into the invocation context.");
             ctx.getContextData().put(SPAN_CONTEXT, span.context());
 
@@ -97,9 +96,7 @@ public class OpenTracingInterceptor {
             throw e;
         } finally {
             span.finish();
-            if(scope != null) {
-                scope.close();
-            }
+            scope.close();
         }
     }
 

--- a/src/test/java/io/opentracing/contrib/interceptors/EjbDeploymentTestCase.java
+++ b/src/test/java/io/opentracing/contrib/interceptors/EjbDeploymentTestCase.java
@@ -97,15 +97,12 @@ public class EjbDeploymentTestCase {
 
         Assert.assertEquals(0, mockTracer.finishedSpans().size());
         Span span = tracer.buildSpan("spanIsIntercepted").start();
-        Scope scope = null;
+        Scope scope = tracer.activateSpan(span);
         try {
-            scope = tracer.activateSpan(span);
             interceptedEJB.withSpanReadyToUse(span);
         } finally {
             span.finish();
-            if (scope != null) {
-                scope.close();
-            }
+            scope.close();
         }
         Assert.assertEquals(2, mockTracer.finishedSpans().size());
         assertSameTrace(mockTracer.finishedSpans());


### PR DESCRIPTION
## Description
Bumping up Open Tracing dependencies:
- upgrading Open Tracing API  to latest available (`0.33.0`)
- upgrading OT TracerResolver to latest available (`0.1.8`)
- adopting `OpenTracingInterceptor` implementation that was affected by API changes